### PR TITLE
Mobile improvements

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/styles/jsdoc.css
+++ b/styles/jsdoc.css
@@ -589,7 +589,8 @@ span.param-type, .params td .param-type, .param-type dd {
 /* Minus */
 .nav-trigger:checked + label {
   -webkit-transform: scale(0.75);
-          transform: scale(0.75);
+          transform: scale(0.75);  
+  background: #2e2e2e;
 }
 
 /* × and + */
@@ -623,6 +624,12 @@ span.param-type, .params td .param-type, .param-type dd {
 
 .nav-trigger:checked ~ .overlay {
   display: block;
+}
+
+@media only screen and (max-width: 680px) { 
+    .nav-trigger:checked ~ .overlay {
+      display: none;
+    }
 }
 
 .nav-trigger {
@@ -677,7 +684,11 @@ html[data-search-mode] .level-hide {
     position: fixed;
     top: 1.5em;
     right: 0;
-    z-index: 2;
+    z-index: 2;    
+    padding: 2rem 1rem;
+    box-shadow: 0 0 8px #0000001f;    
+    background: white;    
+    opacity: 1;
   }
 
   #main {

--- a/styles/jsdoc.css
+++ b/styles/jsdoc.css
@@ -626,7 +626,7 @@ span.param-type, .params td .param-type, .param-type dd {
   display: block;
 }
 
-@media only screen and (max-width: 680px) { 
+@media only screen and (min-width: 680px) { 
     .nav-trigger:checked ~ .overlay {
       display: none;
     }


### PR DESCRIPTION
Add background to the nav-tigger button in order to appear when the pagescroll on the dark areas of code exemple, also add some box shadow to give a better looks when on the white areas.


Also in small page and the menu open, once you resize the page the overlay dont goes away, i've fixed it too.

Preview in https://codersquirrel.github.io/ferrumjsorg/